### PR TITLE
Add Papaya Launcher to supported Frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This fork introduces several enhancements to improve the experience on Android d
 *   **Android Handheld Support:** Tested and verified on devices like the **RG Cube**.
 *   **Virtual Keyboard:** Access the Android keyboard at any time by sliding up from the bottom of the screen.
 *   **Options Menu:** Access the side menu for settings and options by sliding from the left side of the screen or pressing the **Left Shoulder (L1/LB)** button on a controller.
-*   **Frontend Integration:** Compatible with frontends like **ES-DE** to launch PICO-8 games directly or access Splore (see v0.0.7 release notes for setup instructions; pending official integration from the ES-DE team). **Beacon Launcher** support added since v1.0.0 
+*   **Frontend Integration:** Compatible with frontends like **ES-DE** to launch PICO-8 games directly or access Splore (see v0.0.7 release notes for setup instructions; pending official integration from the ES-DE team). **Beacon Launcher** and **Papaya Launcher** support added since v1.0.0 
 *   **Direct Cart Launch:** Launch `.p8.png` cartridges directly from any file manager or web browser. Supports **Deep Links** to launch carts directly from the [Lexaloffle website](https://www.lexaloffle.com/), as well as standard Android "Share Link" and "Share Image" actions.
 *   **2 Player support:** connect 2 controllers and you can play games that support them
 *   **Integrated shaders:** try to one of the integrated shaders to see if you like it more than the original output. They can be modified in /Documents/pico8/shaders . Copy one of the existing rename it in [name].custom.gslang, it will be loaded next time you select it from the menu, without need to restart. The format is Godot shader language, not the standard slang.


### PR DESCRIPTION
Hi there, I'm the dev of [Papaya](https://play.google.com/store/apps/details?id=com.sebschaef.papaya). I just added the support for your Standalone version to it and thought it would be nice to have it in the list of supported Frontends here as well :)

But feel free to reject it, if you feel like it does not fit here.

Thanks for the mazing project!