### PR TITLE
Fixing crash issue

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ package.dat
 .vscode/
 test-data/
 logs/
+
+# Nix
+.direnv/
+result

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "pico8-android development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              android-tools # adb, fastboot
+              scrcpy        # screen mirroring
+              jdk17         # for Godot Android export
+            ];
+
+            shellHook = ''
+              echo ""
+              echo "=== pico8-android dev shell ==="
+              echo ""
+              echo "  ADB commands:"
+              echo "    adb devices                  — list connected devices"
+              echo "    adb logcat -b crash          — view crash logs"
+              echo "    adb logcat *:E               — errors only"
+              echo "    adb logcat | grep -i pico    — filter pico8 logs"
+              echo "    adb logcat --pid=\$(adb shell pidof io.wip.pico8)"
+              echo "                                 — app-specific logs"
+              echo ""
+              echo "  Useful:"
+              echo "    scrcpy                       — mirror device screen"
+              echo "    adb install app.apk          — install APK"
+              echo "    adb shell                    — device shell"
+              echo ""
+            '';
+          };
+        }
+      );
+    };
+}

--- a/frontend/boot.gd
+++ b/frontend/boot.gd
@@ -146,6 +146,29 @@ func get_pico_zip() -> Variant:
 	return null
 
 var android_picker
+var retry_button: Button = null
+
+func _show_setup_error(msg: String) -> void:
+	push_error("pico8-android setup failed: " + msg)
+	%UnpackProgress.text += msg + "\n"
+	# Show a retry button so the user can try again
+	if retry_button == null:
+		retry_button = Button.new()
+		retry_button.text = "RETRY"
+		retry_button.pressed.connect(_on_retry_pressed)
+		%UnpackProgressContainer.add_child(retry_button)
+		# Position below the progress label
+		retry_button.position = Vector2(
+			%UnpackProgress.position.x + %UnpackProgress.size.x / 2 - 20,
+			%UnpackProgress.position.y + %UnpackProgress.size.y + 4
+		)
+	retry_button.visible = true
+
+func _on_retry_pressed() -> void:
+	if retry_button:
+		retry_button.visible = false
+	%UnpackProgress.text = ""
+	setup()
 
 func _ready() -> void:
 	# Wait for the window to be fully initialized to avoid race conditions with focus events
@@ -211,7 +234,7 @@ func setup():
 		var copy_err = public_folder.copy("res://package.dat", tar_path_godot)
 		print("tar copy: ", error_string(copy_err))
 		if copy_err != OK:
-			%UnpackProgress.text += "FAILED (disk full or permission error)\n"
+			_show_setup_error("FAILED extracting bootstrap: %s (disk full or permission error)" % error_string(copy_err))
 			return
 		
 		var tar_exit = OS.execute(
@@ -226,7 +249,7 @@ func setup():
 		)
 		
 		if tar_exit != 0:
-			%UnpackProgress.text += "FAILED (exit code %d). Check logs/tar_err.txt\n" % tar_exit
+			_show_setup_error("FAILED tar extraction (exit code %d). Check logs/tar_err.txt" % tar_exit)
 			return
 
 		%UnpackProgress.text += "done\n"
@@ -247,7 +270,7 @@ func setup():
 		var zip_copy_err = public_folder.copy(pico_zip_path, pico_path_godot)
 		print("pico zip copy: ", error_string(zip_copy_err))
 		if zip_copy_err != OK:
-			%UnpackProgress.text += "FAILED (copy failed: %s)\n" % error_string(zip_copy_err)
+			_show_setup_error("FAILED pico-8 zip copy: %s" % error_string(zip_copy_err))
 			return
 
 		var zip_exit = OS.execute(
@@ -263,15 +286,15 @@ func setup():
 		)
 		
 		if zip_exit != 0:
-			%UnpackProgress.text += "FAILED (exit code %d). Check logs/zip_err.txt\n" % zip_exit
 			# Cleanup to avoid partial extraction being treated as success next time
 			if FileAccess.file_exists(binary_path):
 				DirAccess.remove_absolute(binary_path)
+			_show_setup_error("FAILED zip extraction (exit code %d). Check logs/zip_err.txt" % zip_exit)
 			return
 
 		# Verify if the unzip actually produced the binary
 		if not FileAccess.file_exists(binary_path):
-			%UnpackProgress.text += "FAILED (pico8_64 not found after unzip)\n"
+			_show_setup_error("FAILED (pico8_64 not found after unzip)")
 			return
 
 		%UnpackProgress.text += "done\n"

--- a/frontend/run_pico_cmd.gd
+++ b/frontend/run_pico_cmd.gd
@@ -359,7 +359,9 @@ func _process(_delta: float) -> void:
 			if Time.get_ticks_msec() > process_check_timer:
 				process_check_timer = Time.get_ticks_msec() + 1000
 				if pico_pid and not OS.is_process_running(pico_pid):
-					print("PICO-8 Process died! (PID: " + str(pico_pid) + ")")
+					var msg = "PICO-8 process died unexpectedly (PID: %d). Check logs/pico_err.txt" % pico_pid
+					push_error(msg)
+					print(msg)
 					get_tree().quit()
 				
 		RestartState.REQUESTED:


### PR DESCRIPTION
Issue #68 — the app crashes sometimes and can't load past the memory card loading screen. The changes make failures diagnosable via `adb logcat *:E | grep pico` and recoverable via the retry button.

## Changes
- Setup error logging: silent failure points now logs
- Retry button: dynamically shown when setup fails, so users aren't stuck on the memory card loading screen
- Process death logging:  now logs via  when PICO-8 dies, before quitting

## Next steps
- [ ] Reproduce crash and log
- [ ] Testing